### PR TITLE
Include spelling and readability in linter success criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ pip install .
 content-linter --posts-dir _posts --keywords-file .github/scripts/keywords.txt
 ```
 
+The command exits with a non-zero status if any check fails, including spelling and readability.
+
 ## GitHub Action
 
 ```yaml

--- a/content_linter/__init__.py
+++ b/content_linter/__init__.py
@@ -188,7 +188,17 @@ def run(posts_dir="_posts", keywords_file=".github/scripts/keywords.txt"):
         print(f"Readability: {readability_ok}")
         print("::endgroup::")
 
-        if not all([seo_ok, keywords_ok, links_ok, headings_ok, images_ok]):
+        if not all(
+            [
+                seo_ok,
+                keywords_ok,
+                links_ok,
+                headings_ok,
+                images_ok,
+                spelling_ok,
+                readability_ok,
+            ]
+        ):
             overall_success = False
             print(f"::error::Some checks failed for {post}")
 


### PR DESCRIPTION
## Summary
- Ensure the linter fails when spelling or readability checks fail
- Document that any failed check exits the CLI with non-zero status

## Testing
- `pytest -q`
- `python -m content_linter.cli --posts-dir _posts --keywords-file .github/scripts/keywords.txt && echo PASSED` *(fails as expected, no `PASSED` output)*

------
https://chatgpt.com/codex/tasks/task_e_68a6392a54c08328a2307d8c1ed4dd57